### PR TITLE
throw typed exceptions for easier error handling, with String .message same as previous string exception

### DIFF
--- a/lib/isolate_pool_2.dart
+++ b/lib/isolate_pool_2.dart
@@ -20,6 +20,23 @@ int _instanceIdCounter = 0;
 //TODO consider adding timeouts, check fulfilled requests are deleted
 Map<int, Completer> _isolateRequestCompleters = {}; // requestId is key
 
+class IsolatePoolBaseException implements Exception {
+  final String message;
+  IsolatePoolBaseException(this.message);
+
+  @override
+  String toString() => message;
+}
+// These are the exceptions this API directly throws, each having a "message" String inherited from IsolatePoolBaseException
+// Note: completers' error can be an `IsolatePoolJobsCancelled` now instead of String.
+// To easily migrate `catch (e)` blocks that expect a string, use `e.toString()` for the same error string as before
+class NoSuchIsolateInstance extends IsolatePoolBaseException {  NoSuchIsolateInstance(super.message); }
+class IsolatePoolStopped extends IsolatePoolBaseException { IsolatePoolStopped(super.message); }
+class IsolatePoolJobCancelled extends IsolatePoolBaseException { IsolatePoolJobCancelled(super.message); }
+class IsolateNotYetStarted extends IsolatePoolBaseException { IsolateNotYetStarted(super.message); }
+class BadResponseReceivedError extends IsolatePoolBaseException { BadResponseReceivedError(super.message); }
+
+
 /// Inherti when using pooled instances and defining actions.
 /// Action objects are holders of action type and payload/params when calling pooled intances
 abstract class Action {}
@@ -52,7 +69,7 @@ class PooledInstanceProxy {
   /// should the action fail in the executing isolate
   Future<R> callRemoteMethod<R>(Action action) {
     if (_pool.state == IsolatePoolState.stoped) {
-      throw 'Isolate pool has been stoped, cant call pooled instnace method';
+      throw IsolatePoolStopped('Isolate pool has been stoped, cant call pooled instnace method');
     }
     return _pool._sendRequest<R>(_instanceId, action);
   }
@@ -165,7 +182,7 @@ class IsolatePool {
   /// should the action fail in the executing isolate
   Future<T> scheduleJob<T>(PooledJob job) {
     if (state == IsolatePoolState.stoped) {
-      throw 'Isolate pool has been stoped, cant schedule a job';
+      throw IsolatePoolStopped('Isolate pool has been stoped, cant schedule a job');
     }
     _jobs[lastJobStartedIndex] =
         _PooledJobInternal(job, lastJobStartedIndex, -1);
@@ -180,7 +197,7 @@ class IsolatePool {
   void destroyInstance(PooledInstanceProxy instance) {
     var index = indexOfPi(instance);
     if (index == -1) {
-      throw 'Cant find instance with id ${instance._instanceId} among active to destroy it';
+      throw NoSuchIsolateInstance('Cant find instance with id ${instance._instanceId} among active to destroy it');
     }
 
     _isolateSendPorts[index]!.send(_DestroyRequest(instance._instanceId));
@@ -340,11 +357,11 @@ class IsolatePool {
 
   Future<R> _sendRequest<R>(int instanceId, Action action) {
     if (!_pooledInstances.containsKey(instanceId)) {
-      throw 'Cant send request to non-existing instance, instanceId $instanceId';
+      throw NoSuchIsolateInstance('Cant send request to non-existing instance, instanceId $instanceId');
     }
     var pim = _pooledInstances[instanceId]!;
     if (pim.state == _PooledInstanceStatus.starting) {
-      throw 'Cant send request to instance in Starting state, instanceId $instanceId}';
+      throw IsolateNotYetStarted('Cant send request to instance in Starting state, instanceId $instanceId}');
     }
     var index = pim.isolateIndex;
     var request = _Request(instanceId, action);
@@ -383,7 +400,7 @@ class IsolatePool {
       i.kill();
       for (var c in jobCompleters.values) {
         if (!c.isCompleted) {
-          c.completeError('Isolate pool stopped upon request, cancelling jobs');
+          c.completeError(IsolatePoolJobCancelled('Isolate pool stopped upon request, cancelling jobs'));
         }
       }
       jobCompleters.clear();
@@ -391,7 +408,7 @@ class IsolatePool {
       for (var c in creationCompleters.values) {
         if (!c.isCompleted) {
           c.completeError(
-              'Isolate pool stopped upon request, cancelling instance creation requests');
+              IsolatePoolJobCancelled('Isolate pool stopped upon request, cancelling instance creation requests'));
         }
       }
       creationCompleters.clear();
@@ -399,7 +416,7 @@ class IsolatePool {
       for (var c in _requestCompleters.values) {
         if (!c.isCompleted) {
           c.completeError(
-              'Isolate pool stopped upon request, cancelling pending request');
+              IsolatePoolJobCancelled('Isolate pool stopped upon request, cancelling pending request'));
         }
       }
       _requestCompleters.clear();
@@ -416,7 +433,7 @@ void _processResponse(_Response response,
     [Map<int, Completer>? requestCompleters]) {
   var cc = requestCompleters ?? _isolateRequestCompleters;
   if (!cc.containsKey(response.requestId)) {
-    throw 'Responnse to non-existing request (id ${response.requestId}) recevied';
+    throw BadResponseReceivedError('Responnse to non-existing request (id ${response.requestId}) recevied');
   }
   var c = cc[response.requestId]!;
   if (response.error != null) {

--- a/test/isolate_pool_test.dart
+++ b/test/isolate_pool_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 @TestOn('vm')
 
+import 'package:test/expect.dart';
 import 'package:test/test.dart';
 import 'package:isolate_pool_2/isolate_pool_2.dart';
 
@@ -170,8 +171,8 @@ void main() {
       try {
         p.stop();
         print(await Future.wait(futures));
-      } catch (e) {
-        if (e == 'Isolate pool stopped upon request, cancelling jobs') {
+      } on IsolatePoolJobCancelled catch (e) {
+        if (e.toString() == 'Isolate pool stopped upon request, cancelling jobs') {
           thrown = true;
         }
       }

--- a/test/isolate_pool_test.dart
+++ b/test/isolate_pool_test.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 @TestOn('vm')
+library;
 
-import 'package:test/expect.dart';
 import 'package:test/test.dart';
 import 'package:isolate_pool_2/isolate_pool_2.dart';
 

--- a/test/pooled_instance_more_test.dart
+++ b/test/pooled_instance_more_test.dart
@@ -188,15 +188,10 @@ void main() {
     pool.destroyInstance(instances[0]);
     expect(pool.numberOfPooledInstances, 4);
 
-    var err = '';
-
-    try {
-      pool.destroyInstance(instances[0]);
-    } catch (e) {
-      err = e.toString();
-    }
-
-    expect(err != '', true);
+    expect(
+      () => pool.destroyInstance(instances[0]),
+      throwsA(isA<NoSuchIsolateInstance>())
+    );
   });
 
   test('Calling method with pool stopped is handled', () async {
@@ -205,14 +200,10 @@ void main() {
     var pi = await pool.addInstance(WorkerA(), null);
     expect(pool.numberOfPooledInstances, 1);
     pool.stop();
-    var err = '';
-    try {
-      await pi.callRemoteMethod(SumIntAction(1, 1));
-    } catch (e) {
-      err = e.toString();
-    }
     expect(
-        err, 'Isolate pool has been stoped, cant call pooled instnace method');
+      () async => await pi.callRemoteMethod(SumIntAction(1, 1)),
+      throwsA(isA<IsolatePoolStopped>())
+    );
   });
 
   test('Can stop while there\'re instances being created', () async {

--- a/test/pooled_instance_more_test.dart
+++ b/test/pooled_instance_more_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+library;
 
 import 'package:isolate_pool_2/isolate_pool_2.dart';
 import 'package:test/test.dart';
@@ -78,20 +79,20 @@ class WorkerA extends PooledInstance {
 
   @override
   Future receiveRemoteCall(Action action) async {
-    switch (action.runtimeType) {
-      case SumIntAction:
-        var ac = action as SumIntAction;
+    switch (action) {
+      case SumIntAction _:
+        var ac = action;
         return _a.sum(ac.x, ac.y);
-      case ConcatAction:
-        var ac = action as ConcatAction;
+      case ConcatAction _:
+        var ac = action;
         return _a.concat(ac.x, ac.y);
-      case CallbackIssuingAction:
-        var ac = action as CallbackIssuingAction;
+      case CallbackIssuingAction _:
+        var ac = action;
         return _a.deffered(ac.x, (y) async {
           var x = await callRemoteMethod<int>(CallbackAction(y));
           await callRemoteMethod(CallbackAction(x + 1));
         });
-      case FailAction:
+      case FailAction _:
         return _a.fail();
     }
   }
@@ -109,12 +110,12 @@ class WorkerB extends PooledInstance {
 
   @override
   Future receiveRemoteCall(Action action) async {
-    switch (action.runtimeType) {
-      case SumIntAction:
-        var ac = action as SumIntAction;
+    switch (action) {
+      case SumIntAction _:
+        var ac = action;
         return _a.sum(ac.x, ac.y);
-      case SumDynamicAction:
-        var ac = action as SumDynamicAction;
+      case SumDynamicAction _:
+        var ac = action;
         if (ac.x is int) return _a.sum(ac.x, ac.y);
         if (ac.x is double) return _b.sum(ac.x, ac.y);
         throw 'SumDynamic supports only int and double';

--- a/test/pooled_instance_test.dart
+++ b/test/pooled_instance_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: no_leading_underscores_for_local_identifiers
 @TestOn('vm')
+library;
 
 import 'package:test/test.dart';
 import 'package:isolate_pool_2/isolate_pool_2.dart';
@@ -17,11 +18,11 @@ class ValueHolder extends PooledInstance {
 
   @override
   Future<dynamic> receiveRemoteCall(Action action) async {
-    switch (action.runtimeType) {
-      case GetValues:
+    switch (action) {
+      case GetValues _:
         return _values;
-      case SetValue:
-        var v = (action as SetValue).value;
+      case SetValue _:
+        var v = action.value;
         _values.add(v);
         return;
       default:

--- a/test/pooled_instance_test.dart
+++ b/test/pooled_instance_test.dart
@@ -83,7 +83,6 @@ void main() {
 
     expect(
         () => px.callRemoteMethod(GetValues()),
-        throwsA(contains(
-            'Cant send request to non-existing instance, instanceId')));
+        throwsA(isA<NoSuchIsolateInstance>()));
   });
 }


### PR DESCRIPTION
sorry for an unsolicited PR here.

I saw the string exceptions and thought it might be easier to define specific exception types instead, but kept their ```String .message``` values identical, so any code that explicitly uses ```catch (e)``` to check the exception string can use ```e.toString()``` instead without any other changes.

the tests are updated to use the new exception types everywhere applicable that I could find.

any client code can still throw any type in the background isolates.  nothing changes there.

i'm new to dart/flutter, so I hope this is usable for you.  also, thanks for this package: it's tidy and minimalist.  my current (first) app is likely to use this package.  i'm mainly thinking about having long-lived isolates, but thinking that i might need to have multiple simultaneous requests pending to a single isolate that can return results in any order, like an async rpc server (using an autoincrementing request id to match up responses to requests).  but i'm not sure yet.  again, thanks, hope this is useful.